### PR TITLE
feat: check zero count update before sending eligible nodes to relayer

### DIFF
--- a/pkgs/constants.go
+++ b/pkgs/constants.go
@@ -35,4 +35,5 @@ const (
 	EpochSubmissionsKey              = "EpochSubmissionsKey"
 	EligibleSlotSubmissionByEpochKey = "EligibleSlotSubmissionByEpochKey"
 	DiscardedSubmissionKey           = "DiscardedSubmissionKey"
+	ZeroCountKey                     = "ZeroCountKey"
 )

--- a/pkgs/redis/client.go
+++ b/pkgs/redis/client.go
@@ -85,6 +85,26 @@ func Incr(ctx context.Context, key string) (int64, error) {
 	return result, nil
 }
 
+func GetBooleanValue(ctx context.Context, key string) (bool, error) {
+	value, err := RedisClient.Get(ctx, key).Result()
+	if err == redis.Nil {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return value == "true", nil
+}
+
+func SetBooleanValue(ctx context.Context, key string, value bool, ttl time.Duration) error {
+	stringValue := "false"
+	if value {
+		stringValue = "true"
+	}
+
+	return RedisClient.Set(ctx, key, stringValue, ttl).Err()
+}
+
 func GetSetCardinality(ctx context.Context, key string) (int, error) {
 	count, err := RedisClient.SCard(ctx, key).Result()
 	if err != nil {

--- a/pkgs/redis/keys.go
+++ b/pkgs/redis/keys.go
@@ -85,3 +85,7 @@ func EligibleSlotSubmissionsByEpochKey(dataMarketAddress, currentDay, epochID st
 func DiscardedSubmissionsKey(dataMarketAddress, currentDay, epochID string) string {
 	return fmt.Sprintf("%s.%s.%s.%s", pkgs.DiscardedSubmissionKey, strings.ToLower(dataMarketAddress), currentDay, epochID)
 }
+
+func ZeroCountUpdateKey(dataMarketAddress, day string) string {
+	return fmt.Sprintf("%s.%s.%s", pkgs.ZeroCountKey, strings.ToLower(dataMarketAddress), day)
+}


### PR DESCRIPTION
### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
When sending eligible nodes count to the relayer for a period of buffer days, there are continuous alerts being sent for when the recalculated eligible nodes count is zero.

### New expected behaviour
Added a check which ensures that zero count updates are not sent continuously to the contract.