### PR TITLE
feat: add API endpoint to retrieve eligible nodes count for a specific day

### DIFF
--- a/pkgs/service/api.go
+++ b/pkgs/service/api.go
@@ -330,7 +330,7 @@ func handleTotalSubmissions(w http.ResponseWriter, r *http.Request) {
 // @Param includeSlotDetails query bool false "Set to true to include slotIDs in the response"
 // @Param request body EligibleNodesPastDaysRequest true "Eligible nodes count past days payload"
 // @Success 200 {object} Response[ResponseArray[EligibleNodes]]
-// @Failure 400 {string} string "Bad Request: Invalid input parameters (e.g., past days < 1 or invalid data market address)"
+// @Failure 400 {string} string "Bad Request: Invalid input parameters (e.g., past days < 1 or past days > current day, invalid data market address)"
 // @Failure 401 {string} string "Unauthorized: Incorrect token"
 // @Router /eligibleNodesCountPastDays [post]
 func handleEligibleNodesCountPastDays(w http.ResponseWriter, r *http.Request) {
@@ -370,6 +370,13 @@ func handleEligibleNodesCountPastDays(w http.ResponseWriter, r *http.Request) {
 	}
 
 	currentDay := new(big.Int).Set(day)
+
+	// Validate past days does not exceed the current day
+	if request.PastDays > int(currentDay.Int64()) {
+		http.Error(w, fmt.Sprintf("Past days cannot exceed the current day (%d)", currentDay.Int64()), http.StatusBadRequest)
+		return
+	}
+
 	eligibleNodesResponse := make([]EligibleNodes, request.PastDays)
 
 	// Get the includeSlotDetails query parameter value

--- a/pkgs/service/api.go
+++ b/pkgs/service/api.go
@@ -232,7 +232,7 @@ func getEpochSubmissions(epochSubmissionKey string) (map[string]string, error) {
 // @Produce json
 // @Param request body SubmissionsRequest true "Submissions request payload"
 // @Success 200 {object} Response[ResponseArray[DailySubmissions]]
-// @Failure 400 {string} string "Bad Request: Invalid input parameters (e.g., past days < 1, invalid slotID or invalid data market address)"
+// @Failure 400 {string} string "Bad Request: Invalid input parameters (e.g., past days < 1 or past days > current day, invalid slotID or invalid data market address)"
 // @Failure 401 {string} string "Unauthorized: Incorrect token"
 // @Router /totalSubmissions [post]
 func handleTotalSubmissions(w http.ResponseWriter, r *http.Request) {
@@ -278,6 +278,12 @@ func handleTotalSubmissions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	currentDay := new(big.Int).Set(day)
+
+	if request.PastDays > int(currentDay.Int64()) {
+		http.Error(w, fmt.Sprintf("Past days cannot exceed the current day (%d)", currentDay.Int64()), http.StatusBadRequest)
+		return
+	}
+
 	submissionsResponse := make([]DailySubmissions, request.PastDays)
 
 	var wg sync.WaitGroup

--- a/pkgs/service/api.go
+++ b/pkgs/service/api.go
@@ -457,15 +457,14 @@ func handleEligibleNodesCount(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to fetch current day", http.StatusBadRequest)
 		return
 	}
-	currentDay := new(big.Int).Set(day)
 
 	if request.Day < 1 {
 		http.Error(w, "Day must be greater than or equal to 1", http.StatusBadRequest)
 		return
 	}
 
-	if int64(request.Day) > currentDay.Int64() {
-		http.Error(w, fmt.Sprintf("Day must not exceed the current day (%d)", currentDay.Int64()), http.StatusBadRequest)
+	if int64(request.Day) > day.Int64() {
+		http.Error(w, fmt.Sprintf("Day must not exceed the current day (%d)", day.Int64()), http.StatusBadRequest)
 		return
 	}
 

--- a/pkgs/service/api_test.go
+++ b/pkgs/service/api_test.go
@@ -118,6 +118,12 @@ func TestHandleTotalSubmissions(t *testing.T) {
 			response:   nil,
 		},
 		{
+			name:       "Valid token, past days greater than current day",
+			body:       `{"slotID": 1, "token": "valid-token", "pastDays": 6, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			statusCode: http.StatusBadRequest,
+			response:   nil,
+		},
+		{
 			name:       "Invalid token",
 			body:       `{"slotID": 1, "token": "invalid-token", "pastDays": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
 			statusCode: http.StatusUnauthorized,

--- a/pkgs/service/api_test.go
+++ b/pkgs/service/api_test.go
@@ -169,7 +169,7 @@ func TestHandleTotalSubmissions(t *testing.T) {
 	}
 }
 
-func TestHandleEligibleNodeCount(t *testing.T) {
+func TestHandleEligibleNodesCountPastDays(t *testing.T) {
 	// Set the authentication read token
 	config.SettingsObj.AuthReadToken = "valid-token"
 
@@ -194,7 +194,7 @@ func TestHandleEligibleNodeCount(t *testing.T) {
 	}{
 		{
 			name:       "Valid token, past days 1",
-			body:       `{"epochID": 100, "token": "valid-token", "pastDays": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			body:       `{"token": "valid-token", "pastDays": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
 			statusCode: http.StatusOK,
 			response: []EligibleNodes{
 				{Day: 3, Count: 3, SlotIDs: slotIDsForDay3},
@@ -202,7 +202,7 @@ func TestHandleEligibleNodeCount(t *testing.T) {
 		},
 		{
 			name:       "Valid token, past days 3",
-			body:       `{"epochID": 100, "token": "valid-token", "pastDays": 3, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			body:       `{"token": "valid-token", "pastDays": 3, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
 			statusCode: http.StatusOK,
 			response: []EligibleNodes{
 				{Day: 3, Count: 3, SlotIDs: slotIDsForDay3},
@@ -212,25 +212,19 @@ func TestHandleEligibleNodeCount(t *testing.T) {
 		},
 		{
 			name:       "Valid token, negative past days",
-			body:       `{"epochID": 100, "token": "valid-token", "pastDays": -1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			body:       `{"token": "valid-token", "pastDays": -1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
 			statusCode: http.StatusBadRequest,
 			response:   nil,
 		},
 		{
 			name:       "Invalid token",
-			body:       `{"epochID": 100, "token": "invalid-token", "pastDays": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			body:       `{"token": "invalid-token", "pastDays": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
 			statusCode: http.StatusUnauthorized,
 			response:   nil,
 		},
 		{
-			name:       "Invalid EpochID",
-			body:       `{"epochID": -1, "token": "valid-token", "pastDays": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
-			statusCode: http.StatusBadRequest,
-			response:   nil,
-		},
-		{
 			name:       "Invalid Data Market Address",
-			body:       `{"epochID": 100, "token": "valid-token", "pastDays": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200d"}`,
+			body:       `{"token": "valid-token", "pastDays": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200d"}`,
 			statusCode: http.StatusBadRequest,
 			response:   nil,
 		},
@@ -238,7 +232,97 @@ func TestHandleEligibleNodeCount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, err := http.NewRequest("POST", "/eligibleNodesCount", strings.NewReader(tt.body))
+			req, err := http.NewRequest("POST", "/eligibleNodesCountPastDays", strings.NewReader(tt.body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(handleEligibleNodesCountPastDays)
+			testHandler := RequestMiddleware(handler)
+			testHandler.ServeHTTP(rr, req)
+
+			responseBody := rr.Body.String()
+			t.Log("Response Body:", responseBody)
+
+			assert.Equal(t, tt.statusCode, rr.Code)
+
+			if tt.statusCode == http.StatusOK {
+				var response struct {
+					Info struct {
+						Success  bool            `json:"success"`
+						Response []EligibleNodes `json:"response"`
+					} `json:"info"`
+					RequestID string `json:"requestID"`
+				}
+
+				err := json.NewDecoder(rr.Body).Decode(&response)
+				assert.NoError(t, err)
+
+				err = json.Unmarshal([]byte(responseBody), &response)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.response, response.Info.Response)
+			}
+		})
+	}
+}
+
+func TestHandleEligibleNodesCount(t *testing.T) {
+	// Set the authentication read token
+	config.SettingsObj.AuthReadToken = "valid-token"
+
+	// Set the current day
+	redis.Set(context.Background(), redis.GetCurrentDayKey("0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"), "3")
+
+	// Set eligible slotIDs
+	slotIDs := []string{"slot1", "slot2", "slot3"}
+	redis.AddToSet(context.Background(), redis.EligibleNodesByDayKey("0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c", "1"), slotIDs...)
+
+	tests := []struct {
+		name        string
+		body        string
+		queryParams string
+		statusCode  int
+		response    EligibleNodes
+	}{
+		{
+			name:        "Valid token, day 1, includeSlotDetails=true",
+			body:        `{"token": "valid-token", "day": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			queryParams: "?includeSlotDetails=true",
+			statusCode:  http.StatusOK,
+			response:    EligibleNodes{Day: 1, Count: 3, SlotIDs: slotIDs},
+		},
+		{
+			name:        "Valid token, day 1, includeSlotDetails=false",
+			body:        `{"token": "valid-token", "day": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			queryParams: "?includeSlotDetails=false",
+			statusCode:  http.StatusOK,
+			response:    EligibleNodes{Day: 1, Count: 3},
+		},
+		{
+			name:       "Invalid token",
+			body:       `{"token": "invalid-token", "day": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			statusCode: http.StatusUnauthorized,
+			response:   EligibleNodes{},
+		},
+		{
+			name:       "Invalid day",
+			body:       `{"token": "valid-token", "day": 4, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			statusCode: http.StatusBadRequest,
+			response:   EligibleNodes{},
+		},
+		{
+			name:       "Invalid Data Market Address",
+			body:       `{"token": "valid-token", "day": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200d"}`,
+			statusCode: http.StatusBadRequest,
+			response:   EligibleNodes{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "/eligibleNodesCount"+tt.queryParams, strings.NewReader(tt.body))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -257,8 +341,8 @@ func TestHandleEligibleNodeCount(t *testing.T) {
 			if tt.statusCode == http.StatusOK {
 				var response struct {
 					Info struct {
-						Success  bool            `json:"success"`
-						Response []EligibleNodes `json:"response"`
+						Success  bool          `json:"success"`
+						Response EligibleNodes `json:"response"`
 					} `json:"info"`
 					RequestID string `json:"requestID"`
 				}

--- a/pkgs/service/api_test.go
+++ b/pkgs/service/api_test.go
@@ -187,27 +187,30 @@ func TestHandleEligibleNodesCountPastDays(t *testing.T) {
 	redis.AddToSet(context.Background(), redis.EligibleNodesByDayKey("0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c", "1"), slotIDsForDay1...)
 
 	tests := []struct {
-		name       string
-		body       string
-		statusCode int
-		response   []EligibleNodes
+		name        string
+		body        string
+		queryParams string
+		statusCode  int
+		response    []EligibleNodes
 	}{
 		{
-			name:       "Valid token, past days 1",
-			body:       `{"token": "valid-token", "pastDays": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
-			statusCode: http.StatusOK,
+			name:        "Valid token, past days 1, includeSlotDetails=true",
+			body:        `{"token": "valid-token", "pastDays": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			queryParams: "?includeSlotDetails=true",
+			statusCode:  http.StatusOK,
 			response: []EligibleNodes{
 				{Day: 3, Count: 3, SlotIDs: slotIDsForDay3},
 			},
 		},
 		{
-			name:       "Valid token, past days 3",
-			body:       `{"token": "valid-token", "pastDays": 3, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
-			statusCode: http.StatusOK,
+			name:        "Valid token, past days 3, includeSlotDetails=false",
+			body:        `{"token": "valid-token", "pastDays": 3, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			queryParams: "?includeSlotDetails=false",
+			statusCode:  http.StatusOK,
 			response: []EligibleNodes{
-				{Day: 3, Count: 3, SlotIDs: slotIDsForDay3},
-				{Day: 2, Count: 3, SlotIDs: slotIDsForDay2},
-				{Day: 1, Count: 3, SlotIDs: slotIDsForDay1},
+				{Day: 3, Count: 3, SlotIDs: []string{}},
+				{Day: 2, Count: 3, SlotIDs: []string{}},
+				{Day: 1, Count: 3, SlotIDs: []string{}},
 			},
 		},
 		{
@@ -232,7 +235,7 @@ func TestHandleEligibleNodesCountPastDays(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, err := http.NewRequest("POST", "/eligibleNodesCountPastDays", strings.NewReader(tt.body))
+			req, err := http.NewRequest("POST", "/eligibleNodesCountPastDays"+tt.queryParams, strings.NewReader(tt.body))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -298,7 +301,7 @@ func TestHandleEligibleNodesCount(t *testing.T) {
 			body:        `{"token": "valid-token", "day": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
 			queryParams: "?includeSlotDetails=false",
 			statusCode:  http.StatusOK,
-			response:    EligibleNodes{Day: 1, Count: 3},
+			response:    EligibleNodes{Day: 1, Count: 3, SlotIDs: []string{}},
 		},
 		{
 			name:       "Invalid token",

--- a/pkgs/service/api_test.go
+++ b/pkgs/service/api_test.go
@@ -220,6 +220,12 @@ func TestHandleEligibleNodesCountPastDays(t *testing.T) {
 			response:   nil,
 		},
 		{
+			name:       "Valid token, past days greater than current day",
+			body:       `{"token": "valid-token", "pastDays": 4, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
+			statusCode: http.StatusBadRequest,
+			response:   nil,
+		},
+		{
 			name:       "Invalid token",
 			body:       `{"token": "invalid-token", "pastDays": 1, "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
 			statusCode: http.StatusUnauthorized,

--- a/pkgs/service/docs/docs.go
+++ b/pkgs/service/docs/docs.go
@@ -202,7 +202,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1 or invalid data market address)",
+                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1 or past days \u003e current day, invalid data market address)",
                         "schema": {
                             "type": "string"
                         }

--- a/pkgs/service/docs/docs.go
+++ b/pkgs/service/docs/docs.go
@@ -444,7 +444,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1, invalid slotID or invalid data market address)",
+                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1 or past days \u003e current day, invalid slotID or invalid data market address)",
                         "schema": {
                             "type": "string"
                         }

--- a/pkgs/service/docs/docs.go
+++ b/pkgs/service/docs/docs.go
@@ -114,7 +114,7 @@ const docTemplate = `{
         },
         "/eligibleNodesCount": {
             "post": {
-                "description": "Retrieves the total count of eligible nodes along with their corresponding slotIDs for a specified data market address and epochID across a specified number of past days",
+                "description": "Retrieves the total count of eligible nodes and optionally their corresponding slotIDs (controlled by the includeSlotDetails query param) for a specified data market address and day",
                 "consumes": [
                     "application/json"
                 ],
@@ -122,17 +122,69 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Eligible Nodes Count"
+                    "Eligible Nodes"
                 ],
-                "summary": "Get eligible nodes count",
+                "summary": "Get eligible nodes count for a specific day",
                 "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Set to true to include slotIDs in the response",
+                        "name": "includeSlotDetails",
+                        "in": "query"
+                    },
                     {
                         "description": "Eligible nodes count payload",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/service.EligibleNodesRequest"
+                            "$ref": "#/definitions/service.EligibleNodesCountRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.Response-service_EligibleNodes"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid input parameters (e.g., day \u003c 1 or day \u003e current day, invalid data market address)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: Incorrect token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/eligibleNodesCountPastDays": {
+            "post": {
+                "description": "Retrieves the total count of eligible nodes along with their corresponding slotIDs for a specified data market address across a specified number of past days",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Eligible Nodes"
+                ],
+                "summary": "Get eligible nodes count for past days",
+                "parameters": [
+                    {
+                        "description": "Eligible nodes count past days payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/service.EligibleNodesPastDaysRequest"
                         }
                     }
                 ],
@@ -144,7 +196,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1, missing or invalid epochID, or invalid data market address)",
+                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1 or invalid data market address)",
                         "schema": {
                             "type": "string"
                         }
@@ -483,14 +535,25 @@ const docTemplate = `{
                 }
             }
         },
-        "service.EligibleNodesRequest": {
+        "service.EligibleNodesCountRequest": {
             "type": "object",
             "properties": {
                 "dataMarketAddress": {
                     "type": "string"
                 },
-                "epochID": {
+                "day": {
                     "type": "integer"
+                },
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.EligibleNodesPastDaysRequest": {
+            "type": "object",
+            "properties": {
+                "dataMarketAddress": {
+                    "type": "string"
                 },
                 "pastDays": {
                     "type": "integer"
@@ -583,6 +646,17 @@ const docTemplate = `{
             "properties": {
                 "response": {
                     "$ref": "#/definitions/service.DiscardedSubmissionsAPIResponse"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "service.InfoType-service_EligibleNodes": {
+            "type": "object",
+            "properties": {
+                "response": {
+                    "$ref": "#/definitions/service.EligibleNodes"
                 },
                 "success": {
                     "type": "boolean"
@@ -686,6 +760,17 @@ const docTemplate = `{
             "properties": {
                 "info": {
                     "$ref": "#/definitions/service.InfoType-service_DiscardedSubmissionsAPIResponse"
+                },
+                "requestID": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.Response-service_EligibleNodes": {
+            "type": "object",
+            "properties": {
+                "info": {
+                    "$ref": "#/definitions/service.InfoType-service_EligibleNodes"
                 },
                 "requestID": {
                     "type": "string"

--- a/pkgs/service/docs/docs.go
+++ b/pkgs/service/docs/docs.go
@@ -179,6 +179,12 @@ const docTemplate = `{
                 "summary": "Get eligible nodes count for past days",
                 "parameters": [
                     {
+                        "type": "boolean",
+                        "description": "Set to true to include slotIDs in the response",
+                        "name": "includeSlotDetails",
+                        "in": "query"
+                    },
+                    {
                         "description": "Eligible nodes count past days payload",
                         "name": "request",
                         "in": "body",

--- a/pkgs/service/docs/swagger.json
+++ b/pkgs/service/docs/swagger.json
@@ -176,6 +176,12 @@
                 "summary": "Get eligible nodes count for past days",
                 "parameters": [
                     {
+                        "type": "boolean",
+                        "description": "Set to true to include slotIDs in the response",
+                        "name": "includeSlotDetails",
+                        "in": "query"
+                    },
+                    {
                         "description": "Eligible nodes count past days payload",
                         "name": "request",
                         "in": "body",

--- a/pkgs/service/docs/swagger.json
+++ b/pkgs/service/docs/swagger.json
@@ -441,7 +441,7 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1, invalid slotID or invalid data market address)",
+                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1 or past days \u003e current day, invalid slotID or invalid data market address)",
                         "schema": {
                             "type": "string"
                         }

--- a/pkgs/service/docs/swagger.json
+++ b/pkgs/service/docs/swagger.json
@@ -111,7 +111,7 @@
         },
         "/eligibleNodesCount": {
             "post": {
-                "description": "Retrieves the total count of eligible nodes along with their corresponding slotIDs for a specified data market address and epochID across a specified number of past days",
+                "description": "Retrieves the total count of eligible nodes and optionally their corresponding slotIDs (controlled by the includeSlotDetails query param) for a specified data market address and day",
                 "consumes": [
                     "application/json"
                 ],
@@ -119,17 +119,69 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Eligible Nodes Count"
+                    "Eligible Nodes"
                 ],
-                "summary": "Get eligible nodes count",
+                "summary": "Get eligible nodes count for a specific day",
                 "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Set to true to include slotIDs in the response",
+                        "name": "includeSlotDetails",
+                        "in": "query"
+                    },
                     {
                         "description": "Eligible nodes count payload",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/service.EligibleNodesRequest"
+                            "$ref": "#/definitions/service.EligibleNodesCountRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.Response-service_EligibleNodes"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid input parameters (e.g., day \u003c 1 or day \u003e current day, invalid data market address)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: Incorrect token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/eligibleNodesCountPastDays": {
+            "post": {
+                "description": "Retrieves the total count of eligible nodes along with their corresponding slotIDs for a specified data market address across a specified number of past days",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Eligible Nodes"
+                ],
+                "summary": "Get eligible nodes count for past days",
+                "parameters": [
+                    {
+                        "description": "Eligible nodes count past days payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/service.EligibleNodesPastDaysRequest"
                         }
                     }
                 ],
@@ -141,7 +193,7 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1, missing or invalid epochID, or invalid data market address)",
+                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1 or invalid data market address)",
                         "schema": {
                             "type": "string"
                         }
@@ -480,14 +532,25 @@
                 }
             }
         },
-        "service.EligibleNodesRequest": {
+        "service.EligibleNodesCountRequest": {
             "type": "object",
             "properties": {
                 "dataMarketAddress": {
                     "type": "string"
                 },
-                "epochID": {
+                "day": {
                     "type": "integer"
+                },
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.EligibleNodesPastDaysRequest": {
+            "type": "object",
+            "properties": {
+                "dataMarketAddress": {
+                    "type": "string"
                 },
                 "pastDays": {
                     "type": "integer"
@@ -580,6 +643,17 @@
             "properties": {
                 "response": {
                     "$ref": "#/definitions/service.DiscardedSubmissionsAPIResponse"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "service.InfoType-service_EligibleNodes": {
+            "type": "object",
+            "properties": {
+                "response": {
+                    "$ref": "#/definitions/service.EligibleNodes"
                 },
                 "success": {
                     "type": "boolean"
@@ -683,6 +757,17 @@
             "properties": {
                 "info": {
                     "$ref": "#/definitions/service.InfoType-service_DiscardedSubmissionsAPIResponse"
+                },
+                "requestID": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.Response-service_EligibleNodes": {
+            "type": "object",
+            "properties": {
+                "info": {
+                    "$ref": "#/definitions/service.InfoType-service_EligibleNodes"
                 },
                 "requestID": {
                     "type": "string"

--- a/pkgs/service/docs/swagger.json
+++ b/pkgs/service/docs/swagger.json
@@ -199,7 +199,7 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1 or invalid data market address)",
+                        "description": "Bad Request: Invalid input parameters (e.g., past days \u003c 1 or past days \u003e current day, invalid data market address)",
                         "schema": {
                             "type": "string"
                         }

--- a/pkgs/service/docs/swagger.yaml
+++ b/pkgs/service/docs/swagger.yaml
@@ -417,7 +417,7 @@ paths:
             $ref: '#/definitions/service.Response-service_ResponseArray-service_EligibleNodes'
         "400":
           description: 'Bad Request: Invalid input parameters (e.g., past days < 1
-            or invalid data market address)'
+            or past days > current day, invalid data market address)'
           schema:
             type: string
         "401":

--- a/pkgs/service/docs/swagger.yaml
+++ b/pkgs/service/docs/swagger.yaml
@@ -398,6 +398,10 @@ paths:
         slotIDs for a specified data market address across a specified number of past
         days
       parameters:
+      - description: Set to true to include slotIDs in the response
+        in: query
+        name: includeSlotDetails
+        type: boolean
       - description: Eligible nodes count past days payload
         in: body
         name: request

--- a/pkgs/service/docs/swagger.yaml
+++ b/pkgs/service/docs/swagger.yaml
@@ -585,8 +585,8 @@ paths:
           schema:
             $ref: '#/definitions/service.Response-service_ResponseArray-service_DailySubmissions'
         "400":
-          description: 'Bad Request: Invalid input parameters (e.g., past days < 1,
-            invalid slotID or invalid data market address)'
+          description: 'Bad Request: Invalid input parameters (e.g., past days < 1
+            or past days > current day, invalid slotID or invalid data market address)'
           schema:
             type: string
         "401":

--- a/pkgs/service/docs/swagger.yaml
+++ b/pkgs/service/docs/swagger.yaml
@@ -52,12 +52,19 @@ definitions:
           type: string
         type: array
     type: object
-  service.EligibleNodesRequest:
+  service.EligibleNodesCountRequest:
     properties:
       dataMarketAddress:
         type: string
-      epochID:
+      day:
         type: integer
+      token:
+        type: string
+    type: object
+  service.EligibleNodesPastDaysRequest:
+    properties:
+      dataMarketAddress:
+        type: string
       pastDays:
         type: integer
       token:
@@ -117,6 +124,13 @@ definitions:
     properties:
       response:
         $ref: '#/definitions/service.DiscardedSubmissionsAPIResponse'
+      success:
+        type: boolean
+    type: object
+  service.InfoType-service_EligibleNodes:
+    properties:
+      response:
+        $ref: '#/definitions/service.EligibleNodes'
       success:
         type: boolean
     type: object
@@ -183,6 +197,13 @@ definitions:
     properties:
       info:
         $ref: '#/definitions/service.InfoType-service_DiscardedSubmissionsAPIResponse'
+      requestID:
+        type: string
+    type: object
+  service.Response-service_EligibleNodes:
+    properties:
+      info:
+        $ref: '#/definitions/service.InfoType-service_EligibleNodes'
       requestID:
         type: string
     type: object
@@ -336,16 +357,53 @@ paths:
     post:
       consumes:
       - application/json
-      description: Retrieves the total count of eligible nodes along with their corresponding
-        slotIDs for a specified data market address and epochID across a specified
-        number of past days
+      description: Retrieves the total count of eligible nodes and optionally their
+        corresponding slotIDs (controlled by the includeSlotDetails query param) for
+        a specified data market address and day
       parameters:
+      - description: Set to true to include slotIDs in the response
+        in: query
+        name: includeSlotDetails
+        type: boolean
       - description: Eligible nodes count payload
         in: body
         name: request
         required: true
         schema:
-          $ref: '#/definitions/service.EligibleNodesRequest'
+          $ref: '#/definitions/service.EligibleNodesCountRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/service.Response-service_EligibleNodes'
+        "400":
+          description: 'Bad Request: Invalid input parameters (e.g., day < 1 or day
+            > current day, invalid data market address)'
+          schema:
+            type: string
+        "401":
+          description: 'Unauthorized: Incorrect token'
+          schema:
+            type: string
+      summary: Get eligible nodes count for a specific day
+      tags:
+      - Eligible Nodes
+  /eligibleNodesCountPastDays:
+    post:
+      consumes:
+      - application/json
+      description: Retrieves the total count of eligible nodes along with their corresponding
+        slotIDs for a specified data market address across a specified number of past
+        days
+      parameters:
+      - description: Eligible nodes count past days payload
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/service.EligibleNodesPastDaysRequest'
       produces:
       - application/json
       responses:
@@ -354,17 +412,17 @@ paths:
           schema:
             $ref: '#/definitions/service.Response-service_ResponseArray-service_EligibleNodes'
         "400":
-          description: 'Bad Request: Invalid input parameters (e.g., past days < 1,
-            missing or invalid epochID, or invalid data market address)'
+          description: 'Bad Request: Invalid input parameters (e.g., past days < 1
+            or invalid data market address)'
           schema:
             type: string
         "401":
           description: 'Unauthorized: Incorrect token'
           schema:
             type: string
-      summary: Get eligible nodes count
+      summary: Get eligible nodes count for past days
       tags:
-      - Eligible Nodes Count
+      - Eligible Nodes
   /eligibleSlotSubmissionCount:
     post:
       consumes:


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #21 

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

#### Sample Request
```
{
  "dataMarketAddress": "0xabc",
  "day": 1,
  "token": "valid-token"
}
```

#### Sample Response
```
{
  "day": 1,
  "eligibleNodesCount": 3,
  "slotIDs": [
        "slotID1",
        "slotID2",
        "slotID3"
   ]
}
```

### Change logs

#### Added
<!-- Edit these points below to describe the new features added with this PR -->
* `EligibleNodesRequest` to include `dataMarketAddress`, `day` and `token`.
* API endpoint `/eligibleNodesCount` to return the eligible nodes count and optionally the corresponding slotIDs (controlled by the `includeSlotDetails` query param) for a specific data market address and day
* Testcase for this new endpoint
* A check to validate that the `pastDays` parameter in API requests does not exceed the current day, to avoid negative values

#### Changed 
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
* Existing API endpoint which was previously under `/eligibleNodesCount` -> `/eligibleNodesCountPastDays` to return the eligible nodes count and corresponding slotIDs for a specific data market over a specified number of past days
* `EligibleNodesRequest` -> `EligibleNodesPastDaysRequest`
* Existing testcase for the endpoint change
* Swagger docs

#### Removed
* `EpochID` which was previously there in eligible nodes endpoint now `(/eligibleNodesCountPastDays)`, it wasn't being used anywhere

## Deployment Instructions

Pull the latest `dockerify` image tag
