### PR TITLE
feat: add periodic cleanup to remove stale epoch marker keys

### DIFF
--- a/pkgs/prost/detector.go
+++ b/pkgs/prost/detector.go
@@ -59,6 +59,9 @@ func StartFetchingBlocks() {
 			// Process the events in the block
 			go ProcessEvents(block)
 
+			// Start periodic cleanup of stale epoch marker keys
+			go startPeriodicCleanupRoutine(context.Background(), block)
+
 			// Add block number and its hash to Redis
 			if err = redis.SetWithExpiration(context.Background(), redis.BlockHashByNumber(blockNum), block.Hash().Hex(), 30*time.Minute); err != nil {
 				log.Errorf("Failed to set block hash for block number %d in Redis: %s", blockNum, err)

--- a/pkgs/prost/helpers.go
+++ b/pkgs/prost/helpers.go
@@ -166,8 +166,8 @@ func startPeriodicCleanup(currentBlockNum int64) {
 		}(dataMarketAddress)
 	}
 
-	log.Infof("🧹 Completed cleanup for all stale epoch markers")
-
 	// Wait for all data market goroutines to finish
 	wg.Wait()
+
+	log.Infof("🧹 Completed cleanup for all stale epoch markers")
 }

--- a/pkgs/prost/helpers.go
+++ b/pkgs/prost/helpers.go
@@ -2,14 +2,17 @@ package prost
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"submission-sequencer-collector/config"
 	"submission-sequencer-collector/pkgs"
 	"submission-sequencer-collector/pkgs/clients"
 	"submission-sequencer-collector/pkgs/redis"
+	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core/types"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -87,4 +90,83 @@ func fetchEligibleSlotIDs(dataMarketAddress, day string) (int, []string) {
 
 	// Return the slot IDs and their count
 	return len(slotIDs), slotIDs
+}
+
+// startPeriodicCleanupRoutine calls startPeriodicCleanup every 10 minutes
+func startPeriodicCleanupRoutine(ctx context.Context, currentBlock *types.Block) {
+	// Get the current block number
+	currentBlockNum := currentBlock.Number().Int64()
+	log.Info("⏰ Periodic cleanup routine started")
+
+	ticker := time.NewTicker(10 * time.Minute) // Configurable interval
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("⏹️ Periodic cleanup routine stopped")
+			return
+		case <-ticker.C:
+			// Start the periodic cleanup for stale epoch markers
+			startPeriodicCleanup(currentBlockNum)
+		}
+	}
+}
+
+// startPeriodicCleanup cleans up stale epoch markers
+func startPeriodicCleanup(currentBlockNum int64) {
+	var wg sync.WaitGroup
+
+	// Cleanup for each data market in parallel
+	for _, dataMarketAddress := range config.SettingsObj.DataMarketAddresses {
+		wg.Add(1)
+
+		go func(dataMarketAddress string) {
+			defer wg.Done()
+
+			log.Infof("🧹 Starting cleanup for stale epoch markers for data market %s at block number: %d", dataMarketAddress, currentBlockNum)
+
+			epochMarkerKeys, err := redis.RedisClient.SMembers(context.Background(), redis.EpochMarkerSet(dataMarketAddress)).Result()
+			if err != nil {
+				log.Errorf("Failed to fetch epoch markers for data market %s during cleanup: %s", dataMarketAddress, err)
+				return
+			}
+
+			for _, epochMarkerKey := range epochMarkerKeys {
+				epochMarkerDetailsJSON, err := redis.RedisClient.Get(context.Background(), redis.EpochMarkerDetails(dataMarketAddress, epochMarkerKey)).Result()
+				if err != nil {
+					log.Errorf("Failed to fetch epoch marker details for key %s during cleanup: %s", epochMarkerKey, err)
+					continue
+				}
+
+				var epochMarkerDetails EpochMarkerDetails
+				if err := json.Unmarshal([]byte(epochMarkerDetailsJSON), &epochMarkerDetails); err != nil {
+					log.Errorf("Failed to unmarshal epoch marker details for key %s during cleanup: %s", epochMarkerKey, err)
+					continue
+				}
+
+				// Remove stale epoch markers if the submission limit block has passed
+				if currentBlockNum > epochMarkerDetails.SubmissionLimitBlockNumber {
+					log.Infof("🗑️ Removing stale epoch marker key %s for data market %s", epochMarkerKey, dataMarketAddress)
+
+					if err := redis.RedisClient.SRem(context.Background(), redis.EpochMarkerSet(dataMarketAddress), epochMarkerKey).Err(); err != nil {
+						log.Errorf("Failed to remove epoch marker key %s from Redis set during cleanup: %s", epochMarkerKey, err)
+						continue
+					}
+
+					if err := redis.RedisClient.Del(context.Background(), redis.EpochMarkerDetails(dataMarketAddress, epochMarkerKey)).Err(); err != nil {
+						log.Errorf("Failed to delete epoch marker details for key %s during cleanup: %s", epochMarkerKey, err)
+						continue
+					}
+
+					log.Infof("✅ Successfully removed stale epoch marker key %s for data market %s", epochMarkerKey, dataMarketAddress)
+				}
+			}
+		}(dataMarketAddress)
+	}
+
+	log.Infof("🧹 Completed cleanup for all stale epoch markers")
+
+	// Wait for all data market goroutines to finish
+	wg.Wait()
 }

--- a/pkgs/prost/processor.go
+++ b/pkgs/prost/processor.go
@@ -375,13 +375,6 @@ func triggerBatchPreparation(dataMarketAddress string, epochID *big.Int, startBl
 
 		log.Infof("✅ Batch %d successfully pushed to Redis and stored for epoch %s in data market %s", batchID.Int64(), epochID.String(), dataMarketAddress)
 	}
-
-	// Remove the epochID and its details from Redis after processing all batches
-	if err := redis.RemoveEpochFromRedis(context.Background(), dataMarketAddress, epochID.String()); err != nil {
-		log.Errorf("Error removing epoch %s from Redis for data market %s: %v", epochID.String(), dataMarketAddress, err)
-	}
-
-	log.Infof("🧹 Successfully removed epoch %s data from Redis for data market %s", epochID.String(), dataMarketAddress)
 }
 
 // Calculate and update total submission count for a data market address


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #23 

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Change logs

#### Added 
<!-- Edit these points below to describe the new features added with this PR -->
* Periodic cleanup mechanism that cleans up the stale epoch marker keys when the current block is greater than the submission limit block number. This is currently set to work every 10 mins.

#### Removed
<!-- Edit these points below to describe the removed features with this PR -->
* Existing cleanup which was happening after then batch details have been submitted to the `finalizer queue`. This is now included as part of the periodic cleanup process.

## Deployment Instructions
Pull the latest `dockerify` image build
