### PR TITLE
30 event collector api epochsubmissiondetails endpoint fixupdate

### DIFF
--- a/pkgs/constants.go
+++ b/pkgs/constants.go
@@ -34,7 +34,6 @@ const (
 	EligibleNodeByDayKey             = "EligibleNodeByDayKey"
 	LastKnownDayKey                  = "LastKnownDayKey"
 	DailySnapshotQuotaTableKey       = "DailySnapshotQuotaTableKey"
-	EpochSubmissionsCountKey         = "EpochSubmissionsCountKey"
 	EpochSubmissionsKey              = "EpochSubmissionsKey"
 	EligibleSlotSubmissionByEpochKey = "EligibleSlotSubmissionByEpochKey"
 	DiscardedSubmissionKey           = "DiscardedSubmissionKey"

--- a/pkgs/redis/keys.go
+++ b/pkgs/redis/keys.go
@@ -74,10 +74,6 @@ func EligibleNodesByDayKey(dataMarketAddress, currentDay string) string {
 	return fmt.Sprintf("%s.%s.%s", pkgs.EligibleNodeByDayKey, strings.ToLower(dataMarketAddress), currentDay)
 }
 
-func EpochSubmissionsCount(dataMarketAddress string, epochID uint64) string {
-	return fmt.Sprintf("%s.%s.%d", pkgs.EpochSubmissionsCountKey, strings.ToLower(dataMarketAddress), epochID)
-}
-
 func EpochSubmissionsKey(dataMarketAddress string, epochID uint64) string {
 	return fmt.Sprintf("%s.%s.%d", pkgs.EpochSubmissionsKey, strings.ToLower(dataMarketAddress), epochID)
 }

--- a/pkgs/service/api.go
+++ b/pkgs/service/api.go
@@ -127,8 +127,7 @@ type SubmissionDetails struct {
 }
 
 type EpochSubmissionSummary struct {
-	SubmissionCount int                 `json:"epochSubmissionCount"`
-	Submissions     []SubmissionDetails `json:"submissions"`
+	Submissions []SubmissionDetails `json:"submissions"`
 }
 
 type EligibleSubmissionCounts struct {
@@ -679,21 +678,6 @@ func handleEpochSubmissionDetails(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fetch the epoch submission count from Redis
-	submissionCountKey := redis.EpochSubmissionsCount(request.DataMarketAddress, uint64(request.EpochID))
-	submissionCountStr, err := redis.Get(r.Context(), submissionCountKey)
-	if err != nil {
-		http.Error(w, "Internal Server Error: Failed to fetch epoch submission count", http.StatusInternalServerError)
-		return
-	}
-
-	// Convert submission count to integer
-	submissionCount, err := strconv.Atoi(submissionCountStr)
-	if err != nil {
-		http.Error(w, "Internal Server Error: Invalid epoch submission format", http.StatusInternalServerError)
-		return
-	}
-
 	// Fetch the epoch submission details from Redis
 	epochSubmissionsKey := redis.EpochSubmissionsKey(request.DataMarketAddress, uint64(request.EpochID))
 	epochSubmissionDetails, err := getEpochSubmissions(r.Context(), epochSubmissionsKey)
@@ -739,8 +723,7 @@ func handleEpochSubmissionDetails(w http.ResponseWriter, r *http.Request) {
 	info := InfoType[EpochSubmissionSummary]{
 		Success: true,
 		Response: EpochSubmissionSummary{
-			SubmissionCount: submissionCount,
-			Submissions:     submissionDetailsList,
+			Submissions: submissionDetailsList,
 		},
 	}
 

--- a/pkgs/service/api_test.go
+++ b/pkgs/service/api_test.go
@@ -458,9 +458,6 @@ func TestHandleEpochSubmissionDetails(t *testing.T) {
 	// Set the authentication read token
 	config.SettingsObj.AuthReadToken = "valid-token"
 
-	// Set the epoch submission count
-	redis.Set(context.Background(), redis.EpochSubmissionsCount("0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c", 123), "10")
-
 	// Set the epoch submission details
 	epochSubmissionKey := redis.EpochSubmissionsKey("0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c", 123)
 	epochSubmissionsMap := getEpochSubmissionDetails(10)
@@ -490,8 +487,7 @@ func TestHandleEpochSubmissionDetails(t *testing.T) {
 			body:       `{"epochID": 123, "token": "valid-token", "dataMarketAddress": "0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"}`,
 			statusCode: http.StatusOK,
 			response: EpochSubmissionSummary{
-				SubmissionCount: 10,
-				Submissions:     epochSubmissionsList,
+				Submissions: epochSubmissionsList,
 			},
 		},
 		{

--- a/pkgs/service/docs/docs.go
+++ b/pkgs/service/docs/docs.go
@@ -739,9 +739,6 @@ const docTemplate = `{
         "service.EpochSubmissionSummary": {
             "type": "object",
             "properties": {
-                "epochSubmissionCount": {
-                    "type": "integer"
-                },
                 "submissions": {
                     "type": "array",
                     "items": {

--- a/pkgs/service/docs/swagger.json
+++ b/pkgs/service/docs/swagger.json
@@ -736,9 +736,6 @@
         "service.EpochSubmissionSummary": {
             "type": "object",
             "properties": {
-                "epochSubmissionCount": {
-                    "type": "integer"
-                },
                 "submissions": {
                     "type": "array",
                     "items": {

--- a/pkgs/service/docs/swagger.yaml
+++ b/pkgs/service/docs/swagger.yaml
@@ -150,8 +150,6 @@ definitions:
     type: object
   service.EpochSubmissionSummary:
     properties:
-      epochSubmissionCount:
-        type: integer
       submissions:
         items:
           $ref: '#/definitions/service.SubmissionDetails'


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #30 

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [ ] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The `/epochSubmissionDetails` endpoint available in the event collector currently attempts to pull and serve data that is no longer being collected by the cacher/dequeuer.

### New expected behaviour
The `/epochSubmissionDetails` endpoint will no longer attempt to retrieve the deprecated submission count data from redis before attempting to return a response. The endpoint will return only the submission details for the provided epochId.

The associated redis key has also been removed.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


#### Changed
- pkgs/constants.go
- pkgs/redis/keys.go
- pkgs/service/api.go
- pkgs/service/api_test.go

## Deployment Instructions
These changes have been deployed to staging.
