### PR TITLE
Feat/node monitoring endpoint

### DIFF
--- a/pkgs/constants.go
+++ b/pkgs/constants.go
@@ -42,4 +42,5 @@ const (
 	ZeroCountKey                     = "ZeroCountKey"
 	LastSimulatedSubmissionKey       = "LastSimulatedSubmissionKey"
 	LastSnapshotSubmissionKey        = "LastSnapshotSubmissionKey"
+	ActiveSnapshottersForEpoch       = "ActiveSnapshottersForEpoch"
 )

--- a/pkgs/redis/keys.go
+++ b/pkgs/redis/keys.go
@@ -109,3 +109,7 @@ func LastSnapshotSubmission(dataMarketAddress string, slotID uint64) string {
 func TotalNodesCountKey() string {
 	return pkgs.TotalNodesCount
 }
+
+func ActiveSnapshottersForEpoch(dataMarketAddress string, epochID uint64) string {
+	return fmt.Sprintf("%s.%s.%d", pkgs.ActiveSnapshottersForEpoch, strings.ToLower(dataMarketAddress), epochID)
+}

--- a/pkgs/service/docs/docs.go
+++ b/pkgs/service/docs/docs.go
@@ -20,6 +20,58 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/activeNodesCountByEpoch": {
+            "post": {
+                "description": "Retrieves the count of active nodes that submitted snapshots for a specific epoch in a given data market",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Active Nodes"
+                ],
+                "summary": "Get active nodes count for an epoch",
+                "parameters": [
+                    {
+                        "description": "Epoch data market request payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/service.EpochDataMarketRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.Response-int64"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid input parameters (e.g., missing or invalid epochID, or invalid data market address)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: Incorrect token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error: Failed to fetch epoch active nodes count",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/batchCount": {
             "post": {
                 "description": "Retrieves the total number of batches created within a specific epoch for a given data market address",
@@ -750,6 +802,17 @@ const docTemplate = `{
                 }
             }
         },
+        "service.InfoType-int64": {
+            "type": "object",
+            "properties": {
+                "response": {
+                    "type": "integer"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
         "service.InfoType-service_BatchCount": {
             "type": "object",
             "properties": {
@@ -871,6 +934,17 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "snapshotCID": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.Response-int64": {
+            "type": "object",
+            "properties": {
+                "info": {
+                    "$ref": "#/definitions/service.InfoType-int64"
+                },
+                "requestID": {
                     "type": "string"
                 }
             }

--- a/pkgs/service/docs/swagger.json
+++ b/pkgs/service/docs/swagger.json
@@ -17,6 +17,58 @@
     "host": "{{API_Host}}",
     "basePath": "/",
     "paths": {
+        "/activeNodesCountByEpoch": {
+            "post": {
+                "description": "Retrieves the count of active nodes that submitted snapshots for a specific epoch in a given data market",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Active Nodes"
+                ],
+                "summary": "Get active nodes count for an epoch",
+                "parameters": [
+                    {
+                        "description": "Epoch data market request payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/service.EpochDataMarketRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.Response-int64"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid input parameters (e.g., missing or invalid epochID, or invalid data market address)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: Incorrect token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error: Failed to fetch epoch active nodes count",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/batchCount": {
             "post": {
                 "description": "Retrieves the total number of batches created within a specific epoch for a given data market address",
@@ -747,6 +799,17 @@
                 }
             }
         },
+        "service.InfoType-int64": {
+            "type": "object",
+            "properties": {
+                "response": {
+                    "type": "integer"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
         "service.InfoType-service_BatchCount": {
             "type": "object",
             "properties": {
@@ -868,6 +931,17 @@
                     "type": "integer"
                 },
                 "snapshotCID": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.Response-int64": {
+            "type": "object",
+            "properties": {
+                "info": {
+                    "$ref": "#/definitions/service.InfoType-int64"
+                },
+                "requestID": {
                     "type": "string"
                 }
             }

--- a/pkgs/service/docs/swagger.yaml
+++ b/pkgs/service/docs/swagger.yaml
@@ -157,6 +157,13 @@ definitions:
           $ref: '#/definitions/service.SubmissionDetails'
         type: array
     type: object
+  service.InfoType-int64:
+    properties:
+      response:
+        type: integer
+      success:
+        type: boolean
+    type: object
   service.InfoType-service_BatchCount:
     properties:
       response:
@@ -235,6 +242,13 @@ definitions:
       slotID:
         type: integer
       snapshotCID:
+        type: string
+    type: object
+  service.Response-int64:
+    properties:
+      info:
+        $ref: '#/definitions/service.InfoType-int64'
+      requestID:
         type: string
     type: object
   service.Response-service_BatchCount:
@@ -348,6 +362,43 @@ info:
   title: Sequencer API Documentation
   version: "1.0"
 paths:
+  /activeNodesCountByEpoch:
+    post:
+      consumes:
+      - application/json
+      description: Retrieves the count of active nodes that submitted snapshots for
+        a specific epoch in a given data market
+      parameters:
+      - description: Epoch data market request payload
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/service.EpochDataMarketRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/service.Response-int64'
+        "400":
+          description: 'Bad Request: Invalid input parameters (e.g., missing or invalid
+            epochID, or invalid data market address)'
+          schema:
+            type: string
+        "401":
+          description: 'Unauthorized: Incorrect token'
+          schema:
+            type: string
+        "500":
+          description: 'Internal Server Error: Failed to fetch epoch active nodes
+            count'
+          schema:
+            type: string
+      summary: Get active nodes count for an epoch
+      tags:
+      - Active Nodes
   /batchCount:
     post:
       consumes:


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #31

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [ ] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
There is currently no endpoint available to serve the active node count for each epoch in the event detector api.

### New expected behaviour
An `/activeNodesCountByEpoch` endpoint has been added. This will get the data from the shared `ActiveSnapshottersForEpoch` redis key which is updated on a successful submission by the sequencer dequeuer.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


#### Changed
- pkgs/constants.go
- pkgs/redis/keys.go
- pkgs/service/api.go
- pkgs/service/docs/docs.go
- pkgs/service/docs/swagger.json
- pkgs/service/docs/swagger.yaml



<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
These changes are deployed on staging and devnet.
