### PR TITLE
Submission count key migrations 

### DIFF
--- a/config/settings.go
+++ b/config/settings.go
@@ -46,8 +46,9 @@ type Settings struct {
 	BatchProcessingTimeout      int64
 	MemoryProfilingInterval     int
 	DataMarketMigration         struct {
-		Enabled  bool
-		Mappings []DataMarketMigrationEntry
+		Enabled       bool
+		Mappings      []DataMarketMigrationEntry
+		DaysToMigrate int
 	}
 }
 
@@ -81,6 +82,15 @@ func LoadConfig() {
 	// Migration settings
 	migrationEnabled := getEnv("ENABLE_MARKET_MIGRATION", "false") == "true"
 	migrationMappings := getEnv("MARKET_MIGRATION_MAPPINGS", "")
+	daysToMigrate, daysToMigrateErr := strconv.Atoi(getEnv("MARKET_MIGRATION_DAYS", "1"))
+	if daysToMigrateErr != nil {
+		log.Printf("Invalid MARKET_MIGRATION_DAYS value, using default of 1: %v", daysToMigrateErr)
+		daysToMigrate = 1
+	}
+	if daysToMigrate < 1 {
+		log.Printf("MARKET_MIGRATION_DAYS must be at least 1, using default of 1")
+		daysToMigrate = 1
+	}
 
 	config := Settings{
 		ClientUrl:                   getEnv("PROST_RPC_URL", ""),
@@ -201,6 +211,7 @@ func LoadConfig() {
 			)
 		}
 		config.DataMarketMigration.Enabled = true
+		config.DataMarketMigration.DaysToMigrate = daysToMigrate
 	}
 
 	SettingsObj = &config

--- a/pkgs/prost/contract.go
+++ b/pkgs/prost/contract.go
@@ -369,8 +369,9 @@ func MigrateDataMarketState(ctx context.Context, oldAddr, newAddr common.Address
 	eligibleSlotStats := make(map[string]*SlotMigrationStats)
 	submissionStats := make(map[string]*SlotMigrationStats)
 
-	// Calculate the starting day (last 10 days)
-	startDay := currentDayInt - 9
+	// Calculate the starting day based on configuration
+
+	startDay := currentDayInt - (config.SettingsObj.DataMarketMigration.DaysToMigrate - 1)
 	if startDay < 1 {
 		startDay = 1
 	}

--- a/pkgs/prost/contract.go
+++ b/pkgs/prost/contract.go
@@ -369,8 +369,15 @@ func MigrateDataMarketState(ctx context.Context, oldAddr, newAddr common.Address
 	eligibleSlotStats := make(map[string]*SlotMigrationStats)
 	submissionStats := make(map[string]*SlotMigrationStats)
 
+	// Calculate the starting day (last 10 days)
+	startDay := currentDayInt - 9
+	if startDay < 1 {
+		startDay = 1
+	}
+	log.Infof("Migrating slot data for days %d to %d", startDay, currentDayInt)
+
 	// copy over eligible slot submissions by day by slot ID
-	for day := currentDayInt; day >= 1; day-- {
+	for day := currentDayInt; day >= startDay; day-- {
 		dayStr := strconv.Itoa(day)
 		stats := &SlotMigrationStats{TotalSlots: totalNodesCount}
 		eligibleSlotStats[dayStr] = stats
@@ -389,7 +396,7 @@ func MigrateDataMarketState(ctx context.Context, oldAddr, newAddr common.Address
 	}
 
 	// copy over total submissions by day by slot ID
-	for day := currentDayInt; day >= 1; day-- {
+	for day := currentDayInt; day >= startDay; day-- {
 		dayStr := strconv.Itoa(day)
 		stats := &SlotMigrationStats{TotalSlots: totalNodesCount}
 		submissionStats[dayStr] = stats


### PR DESCRIPTION
Adds submission count key migrations to the data market migration process. This change ensures that submission counts are properly transferred when migrating between data market addresses, maintaining historical submission data integrity.

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The data market migration process currently migrates protocol parameters, epoch markers, day tracking data and eligible nodes data. However, it does not migrate the submission count data stored in Redis, which tracks how many submissions each slot has made historically.

### New expected behaviour
The migration process now includes transferring both eligible slot submissions and total slot submissions data for each slot ID across the configured number of historical days (defaults to 1 day). This ensures submission history is preserved when migrating between data market addresses.

### Test run logs

Tested on porting over to a dummmy contract for the current day and here are the logs for the same:

```
time="2025-03-27T09:35:14Z" level=info msg="Starting data market migration from 0x1b14F2fbA449f1edAF6c04db8DBBb8c1D6B7ECa5 to 0xF41D6BC2491AF3a5d5ca4ebE371c862f99e8dcBb" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:255"
time="2025-03-27T09:35:14Z" level=info msg="Migrating slot data for days 3277 to 3277" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:381"
time="2025-03-27T09:35:22Z" level=info msg="Slot Migration Statistics:" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:425"
time="2025-03-27T09:35:22Z" level=info msg="Eligible Slot Migrations:" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:426"
time="2025-03-27T09:35:22Z" level=info msg="  Day 3277: 720/720 successful" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:428"
time="2025-03-27T09:35:22Z" level=info msg="Submission Migrations:" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:439"
time="2025-03-27T09:35:22Z" level=info msg="  Day 3277: 720/720 successful" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:441"
time="2025-03-27T09:35:22Z" level=info msg="📊 Data Market Migration Report" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:453"
time="2025-03-27T09:35:22Z" level=info msg="Protocol Parameters:" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:454"
time="2025-03-27T09:35:22Z" level=info msg="  SubmissionLimitTable:" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:456"
time="2025-03-27T09:35:22Z" level=info msg="    Value: 120" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:457"
time="2025-03-27T09:35:22Z" level=info msg="  DaySizeTableKey:" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:456"
time="2025-03-27T09:35:22Z" level=info msg="    Value: 9600000" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:457"
time="2025-03-27T09:35:22Z" level=info msg="  DailySnapshotQuotaTableKey:" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:456"
time="2025-03-27T09:35:22Z" level=info msg="    Value: 1" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:457"
time="2025-03-27T09:35:22Z" level=info msg="Sets:" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:463"
time="2025-03-27T09:35:22Z" level=info msg="  DayRolloverEpochMarkerSetKey.0xf41d6bc2491af3a5d5ca4ebe371c862f99e8dcbb: Old members: 192, New members: 192" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:467"
time="2025-03-27T09:35:22Z" level=info msg="  EligibleNodeByDayKey.0xf41d6bc2491af3a5d5ca4ebe371c862f99e8dcbb.3277: Old members: 166, New members: 166" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:467"
time="2025-03-27T09:35:22Z" level=info msg="All key-value pairs migrated successfully" func=submission-sequencer-collector/pkgs/prost.MigrateDataMarketState file="/app/pkgs/prost/contract.go:486"
```

### Change logs

#### Added
- Added migration of EligibleSlotSubmissionKey data for each slot ID
- Added migration of SlotSubmissionKey data for each slot ID
- Added statistics tracking for slot submission migrations
- Added configurable days to migrate parameter (defaults to 1 day)

#### Changed
- Modified MigrateDataMarketState to handle slot submission data
- Updated migration report to include slot migration statistics

### Testing
- Tested migration of submission data between data market addresses
- Verified submission counts are preserved after migration
- Confirmed configurable days parameter works as expected
- Validated statistics reporting for successful/failed migrations


## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
Redeploy with the latest `experimental` build.